### PR TITLE
Adding basic stats/ws endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["rezn-runtime", "reznctl", "common"]

--- a/rezn-runtime/src/router.rs
+++ b/rezn-runtime/src/router.rs
@@ -11,6 +11,7 @@ use crate::{
         apply::apply_handler,
         state::{get_state_handler, get_state_raw_handler},
         stats::get_stats_handler,
+        stats_ws::stats_ws_handler,
     },
     AppState,
 };
@@ -23,6 +24,7 @@ use crate::{
         crate::routes::state::get_state_handler,
         crate::routes::state::get_state_raw_handler,
         crate::routes::stats::get_stats_handler,
+        crate::routes::stats_ws::stats_ws_handler,
     )
 )]
 struct ApiDoc;
@@ -31,6 +33,7 @@ pub(crate) fn build_router(app: Arc<AppState>) -> Router {
     Router::new()
         .route("/apply", post(apply_handler))
         .route("/stats", get(get_stats_handler))
+        .route("/stats/ws", get(stats_ws_handler))
         .route("/state", get(get_state_handler))
         .route("/state/raw", get(get_state_raw_handler))
         .with_state(app)

--- a/rezn-runtime/src/routes/mod.rs
+++ b/rezn-runtime/src/routes/mod.rs
@@ -2,3 +2,4 @@ pub mod apply;
 pub mod common;
 pub mod state;
 pub mod stats;
+pub mod stats_ws;

--- a/rezn-runtime/src/routes/stats_ws.rs
+++ b/rezn-runtime/src/routes/stats_ws.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{ws::Message, State, WebSocketUpgrade},
+    response::IntoResponse,
+};
+
+use crate::AppState;
+
+#[utoipa::path(
+    get,
+    path = "/stats/ws",
+    description = "Exposes container stats via WS",
+    responses(
+        (status = 101, description = "WebSocket upgrade initiated")
+    ),
+    tag = "Streaming"
+)]
+pub async fn stats_ws_handler(
+    State(app): State<Arc<AppState>>,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |mut socket| async move {
+        let mut rx = app.stats_tx.subscribe();
+        while let Ok(ev) = rx.recv().await {
+            // Ignore errors if client closed
+            let _ = socket.send(Message::Text(ev.to_string().into())).await;
+        }
+    })
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new WebSocket endpoint at `/stats/ws` for real-time streaming of container statistics to connected clients.

* **Improvements**
  * Enhanced application state management to support broadcasting container stats updates to multiple WebSocket clients.
  * Improved modularity and clarity in the routing and handler structure for stats streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->